### PR TITLE
Change message color from blue to cyan for increased legibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,7 +60,7 @@ var chatList = blessed.list({
 	top: '0',
 	right: '0',
 	align: 'center',
-	fg: 'red',
+	fg: 'cyan',
 	label: 'Conversations',
 	border: {
 		type: 'line'
@@ -78,7 +78,7 @@ var selectedChatBox = blessed.box({
 	parent: screen,
 	// Possibly support:
 	align: 'center',
-	fg: 'red',
+	fg: 'cyan',
 	height: '5%',
 	width: '75%',
 	top: '0',
@@ -90,7 +90,7 @@ var inputBox = blessed.textbox({
 	parent: screen,
 	// Possibly support:
 	// align: 'center',
-	fg: 'red',
+	fg: 'cyan',
 	height: '15%',
 	label: 'iMessage',
 	border: {
@@ -105,7 +105,7 @@ var outputBox = blessed.list({
 	parent: screen,
 	// Possibly support:
 	// align: 'center',
-	fg: 'red',
+	fg: 'cyan',
 	height: '82%',
 	border: {
 		type: 'line'

--- a/app.js
+++ b/app.js
@@ -60,7 +60,7 @@ var chatList = blessed.list({
 	top: '0',
 	right: '0',
 	align: 'center',
-	fg: 'blue',
+	fg: 'red',
 	label: 'Conversations',
 	border: {
 		type: 'line'
@@ -78,7 +78,7 @@ var selectedChatBox = blessed.box({
 	parent: screen,
 	// Possibly support:
 	align: 'center',
-	fg: 'blue',
+	fg: 'red',
 	height: '5%',
 	width: '75%',
 	top: '0',
@@ -90,7 +90,7 @@ var inputBox = blessed.textbox({
 	parent: screen,
 	// Possibly support:
 	// align: 'center',
-	fg: 'blue',
+	fg: 'red',
 	height: '15%',
 	label: 'iMessage',
 	border: {
@@ -105,7 +105,7 @@ var outputBox = blessed.list({
 	parent: screen,
 	// Possibly support:
 	// align: 'center',
-	fg: 'blue',
+	fg: 'red',
 	height: '82%',
 	border: {
 		type: 'line'


### PR DESCRIPTION
I know this is a super personal preference, but got this up and running today, and this quick change made the app much more usable for me.

It appears as if you intend the app to be used on a black terminal window, given white text for most recent sent message. But the dark blue text I had found to be nearly impossible to read on my screen.

Played around a bit and used Cyan as the default color, as the contrast between it and black reads much much better than the blue. 