### PR TITLE
fixed sendMessage sending shadow variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -454,6 +454,7 @@ function sendMessage(to, message) {
 	} else {
 		imessagemodule.sendMessage(to, message);
 	}
+	sending = false;
 }
 
 setInterval(function() {


### PR DESCRIPTION
Before adding this I could only send one message per execution of the app. Seems to work now for me.
